### PR TITLE
fix typos

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -30,9 +30,9 @@ $ brew install curl
 
 (provided you're using [Homebrew](https://brew.sh/)).
 
-Windows users are able to just install this pacakge since it uses the same, clever "anticonf" that Jeroen uses in the [{curl} pacakge](https://github.com/jeroen/curl). 
+Windows users are able to just install this package since it uses the same, clever "anticonf" that Jeroen uses in the [{curl} package](https://github.com/jeroen/curl). 
 
-The state of the availability of `libcurl` v7.62.0 across Linux distributions is sketch at best (as an example, Ubuntu bionic and comic are not even remotely at the current version). If your distribution does not have >= 7.62.0 available you will need to [compile and install it manually](https://curl.haxx.se/download.html) ensuring the library and headers are available to R to build the package.
+The state of the availability of `libcurl` v7.62.0 across Linux distributions is sketchy at best (as an example, Ubuntu bionic and comic are not even remotely at the current version). If your distribution does not have >= 7.62.0 available you will need to [compile and install it manually](https://curl.haxx.se/download.html) ensuring the library and headers are available to R to build the package.
 
 ## What's Inside The Tin
 


### PR DESCRIPTION
This fixes a few typos. I did not render README.md, yet, since I don't have {hrbrpkghelpr} installed.